### PR TITLE
Provide support to run inside Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:20.04
+
+ARG VERSION=0.9.0
+
+LABEL com.example.vendor="LakeDrops" \
+      maintainer="juergen.haas@lakedrops.com" \
+      version="${VERSION}" \
+      description="An image for running mdshow based on reveal.js."
+
+RUN echo "Adding system components" && \
+    apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive \
+        apt-get install -y -q \
+                autoconf automake curl g++ gcc jq make npm rsync unzip \
+                ca-certificates fonts-liberation libappindicator3-1 libasound2 libatk-bridge2.0-0 libatk1.0-0 \
+                libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libglib2.0-0 \
+                libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 \
+                libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 \
+                libxss1 libxtst6 lsb-release wget xdg-utils && \
+    curl -L -o pandoc.deb https://github.com/jgm/pandoc/releases/download/2.9.2.1/pandoc-2.9.2.1-1-amd64.deb && \
+    dpkg -i pandoc.deb && \
+    rm pandoc.deb
+
+ADD mdshow /usr/local/bin/
+ADD docker-entrypoint.sh /usr/local/bin/
+
+RUN echo "Setup MdShow" && \
+    mdshow setup && \
+    ln -s /opt/mdshow/reveal.js/node_modules/gulp/bin/gulp.js /usr/bin/gulp && \
+    mkdir -p /opt/mdshow/theme && \
+    chmod -R a+rwx /opt/mdshow && \
+    chmod -R a+rwx /opt/mdshow/reveal.js/css/theme/source && \
+    chmod -R a+rwx /opt/mdshow/reveal.js/dist/theme && \
+    \
+    echo "Cleanup" && \
+    apt-get clean && \
+    rm -rf /root/.cache && \
+    rm -rf /var/cache/* && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/log/* && \
+    rm -rf /root/.npm && \
+    echo "Completed"
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN echo "Adding system components" && \
 ADD mdshow /usr/local/bin/
 ADD docker-entrypoint.sh /usr/local/bin/
 
-RUN echo "Setup MdShow" && \
-    mdshow setup && \
+RUN echo "Setup mdshow" && \
+    mdshow setup CONFIG_PATH=/opt && \
     ln -s /opt/mdshow/reveal.js/node_modules/gulp/bin/gulp.js /usr/bin/gulp && \
     mkdir -p /opt/mdshow/theme && \
     chmod -R a+rwx /opt/mdshow && \
@@ -41,5 +41,6 @@ RUN echo "Setup MdShow" && \
     rm -rf /root/.npm && \
     echo "Completed"
 
+WORKDIR /mdshow
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["/bin/bash"]

--- a/assets/pandoc/templates/default.revealjs
+++ b/assets/pandoc/templates/default.revealjs
@@ -24,9 +24,9 @@ $endif$
   <!--   $styles.html()$ -->
   <!-- </style> -->
 $if(theme)$
-  <link rel="stylesheet" href="$revealjs-url$/theme/$theme$.css" id="theme">
+  <link rel="stylesheet" href=".mdshow/theme/$theme$/assets/$theme$.css" id="theme">
 $else$
-  <link rel="stylesheet" href="$revealjs-url$/theme/black.css" id="theme">
+  <link rel="stylesheet" href=".mdshow/theme/black/assets/black.css" id="theme">
 $endif$
 $for(css)$
   <link rel="stylesheet" href="$css$"/>

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- docker "$@"
+fi
+
+# if our command is a valid Docker subcommand, let's invoke it through Docker instead
+# (this allows for "docker run docker ps", etc)
+if docker help "$1" > /dev/null 2>&1; then
+	set -- docker "$@"
+fi
+
+# if we have "--link some-docker:docker" and not DOCKER_HOST, let's set DOCKER_HOST automatically
+if [ -z "$DOCKER_HOST" -a "$DOCKER_PORT_2375_TCP" ]; then
+	export DOCKER_HOST='tcp://docker:2375'
+fi
+
+if [ "$1" = 'dockerd' ]; then
+	cat >&2 <<-'EOW'
+		📎 Hey there!  It looks like you're trying to run a Docker daemon.
+		   You probably should use the "dind" image variant instead, something like:
+		     docker run --privileged --name some-overlay-docker -d docker:stable-dind --storage-driver=overlay
+		   See https://hub.docker.com/_/docker/ for more documentation and usage examples.
+	EOW
+	sleep 3
+fi
+
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 # first arg is `-f` or `--some-option`

--- a/mdshow
+++ b/mdshow
@@ -1,12 +1,13 @@
 #!/usr/bin/make -f
 # TODO: newer versions of env support this: !/usr/bin/env -S make -f
+# NOTE Jürgen Haas: switched from yarn to npm, because yarn does not install node_modules/node-jp/bin
 # Author: Jan Christoph Ebersbach <jceb@e-jc.de>
 # Copyright (c) 2020 Jan Christoph Ebersbach
 # License: Apache-2.0
 
 SHELL := /bin/bash
 
-MDSHOW_CONFIG = ${HOME}/.config/mdshow
+MDSHOW_CONFIG = /opt/mdshow
 SLIDES = slides.md
 BUILD_DIR = .build_$(basename $(SLIDES))
 PORT = 3000
@@ -35,7 +36,7 @@ help:
 	@echo "  Example: make serve PORT=3001 SLIDES=myslides.md"
 	@echo ""
 	@echo "Dependencies:"
-	@echo "  curl, pandoc, unzip, yarn"
+	@echo "  curl, pandoc, unzip, npm"
 
 # {{{1 version
 version:
@@ -66,7 +67,7 @@ programs:
 	@type curl || echo "curl is not installed, required in the setup process"
 	@type pandoc || echo "pandoc is not installed, reqiured for converting markdown into a HTML presentation"
 	@type unzip || echo "unzip is not installed, required in the setup process"
-	@type yarn || echo "yarn is not installed, required for serving the presentation"
+	@type npm || echo "npm is not installed, required for serving the presentation"
 	@type monolith || echo "(optional) monolith is not installed, needed for creating a single file HTML presentation"
 
 $(BUILD_DIR)/reveal.js/defaults.css: $(MDSHOW_CONFIG)/defaults.css
@@ -96,7 +97,7 @@ $(MDSHOW_CONFIG)/reveal.js:
 	mv $@/reveal.js-4.1.0/.??* $@/reveal.js-4.1.0/* $@
 	rmdir $@/reveal.js-4.1.0
 	cd $@ && \
-		yarn && yarn add --dev node-jq decktape
+		npm install && npm add node-jq decktape gulp
 	# workarounds for the new reveal-js release
 	cd $@/dist && \
 		ln -s ../plugin .
@@ -137,6 +138,7 @@ sass: $(MDSHOW_CONFIG)/reveal.js \
 
 .sync-custom-themes: $(wildcard $(MDSHOW_CONFIG)/theme/*/source/*.scss)
 	@[ -n "$^" ] && rsync -u $^ $(MDSHOW_CONFIG)/reveal.js/css/theme/source/ || true
+	@[ -n "$^" ] && cd $(MDSHOW_CONFIG)/reveal.js && gulp css-themes || true
 
 .SECONDEXPANSION:
 .build-themes: $$(addprefix $(MDSHOW_CONFIG)/reveal.js/dist/theme/,$$(addsuffix .css,$$(basename $$(notdir $$(wildcard $(MDSHOW_CONFIG)/reveal.js/css/theme/source/*.scss)))))
@@ -145,13 +147,13 @@ sass: $(MDSHOW_CONFIG)/reveal.js \
 .link-theme-assets: $$(addprefix $(MDSHOW_CONFIG)/reveal.js/dist/theme/,$$(basename $$(notdir $$(wildcard $(MDSHOW_CONFIG)/reveal.js/css/theme/source/*.scss))))
 
 $(MDSHOW_CONFIG)/reveal.js/dist/theme/%.css: $(MDSHOW_CONFIG)/reveal.js/css/theme/source/%.scss
-	cd $(MDSHOW_CONFIG)/reveal.js && yarn gulp css-themes
+	cd $(MDSHOW_CONFIG)/reveal.js && gulp css-themes
 
 $(MDSHOW_CONFIG)/theme/%/assets:
 	mkdir -p $@
 
 $(MDSHOW_CONFIG)/reveal.js/dist/theme/%: $(MDSHOW_CONFIG)/theme/%/assets
-	ln -s $< $@
+	@cp $@.css $<
 
 # {{{1 themes
 themes: $(MDSHOW_CONFIG)/reveal.js/dist $(wildcard $(MDSHOW_CONFIG)/reveal.js/dist/theme/*.css)
@@ -194,7 +196,7 @@ pdf: $(basename $(SLIDES)).pdf
 $(basename $(SLIDES)).pdf: serving build
 	pdf_size="$$($(MDSHOW_CONFIG)/reveal.js/node_modules/node-jq/bin/jq -r '.pdf_size' < $(BUILD_DIR)/config.json)"; \
 		pdf_delay="$$($(MDSHOW_CONFIG)/reveal.js/node_modules/node-jq/bin/jq -r '.pdf_delay' < $(BUILD_DIR)/config.json)"; \
-		$(MDSHOW_CONFIG)/reveal.js/node_modules/.bin/decktape -p $${pdf_delay} -s $${pdf_size} http://localhost:$(PORT)/ $@ || \
+		$(MDSHOW_CONFIG)/reveal.js/node_modules/.bin/decktape -p $${pdf_delay} -s $${pdf_size} --chrome-arg="--no-sandbox" http://localhost:$(PORT)/ $@ || \
 		echo "Failed to create $@. Is the mdshow server running? mdshow serve"
 
 # {{{1 serve
@@ -204,7 +206,7 @@ $(MDSHOW_CONFIG)/reveal.js/mdshow-gulp.js:
 		curl -L https://raw.githubusercontent.com/jceb/mdshow/master/assets/mdshow-gulp.js -o $@
 
 serve: build $(MDSHOW_CONFIG)/reveal.js/mdshow-gulp.js
-	cd $(MDSHOW_CONFIG)/reveal.js && yarn gulp -f mdshow-gulp.js --port=$(PORT) --slides="$(SLIDES)" --root="${PWD}/$(BUILD_DIR)"
+	cd $(MDSHOW_CONFIG)/reveal.js && gulp -f mdshow-gulp.js --port=$(PORT) --slides="$(SLIDES)" --root="${PWD}/$(BUILD_DIR)"
 
 serving:
 	@curl -s -I -o /dev/null http://localhost:$(PORT)
@@ -230,24 +232,24 @@ $(BUILD_DIR)/config.json: $(SLIDES)  $(MDSHOW_CONFIG)/defaults.yaml $(MDSHOW_CON
 
 $(BUILD_DIR)/index.html: $(SLIDES) $(BUILD_DIR)/config.json $(BUILD_DIR)/reveal.js $(BUILD_DIR)/assets $(BUILD_DIR)/.mdshow $(BUILD_DIR)/reveal.js/defaults.css
 	PANDOC_ARGS=; \
-				theme="$$($(MDSHOW_CONFIG)/reveal.js/node_modules/node-jq/bin/jq -r '.theme' < $(BUILD_DIR)/config.json)"; \
-				[ -e "$(MDSHOW_CONFIG)/theme/$${theme}/include/in-header.html" ] && PANDOC_ARGS="$${PANDOC_ARGS} --include-in-header=$(MDSHOW_CONFIG)/theme/$${theme}/include/in-header.html"; \
-				[ -e "$(MDSHOW_CONFIG)/theme/$${theme}/include/before-body.html" ] && PANDOC_ARGS="$${PANDOC_ARGS} --include-before-body=$(MDSHOW_CONFIG)/theme/$${theme}/include/before-body.html"; \
-				[ -e "$(MDSHOW_CONFIG)/theme/$${theme}/include/after-body.html" ] && PANDOC_ARGS="$${PANDOC_ARGS} --include-after-body=$(MDSHOW_CONFIG)/theme/$${theme}/include/after-body.html"; \
-				pandoc \
-				$(MDSHOW_CONFIG)/defaults.yaml \
-				$(SLIDES) \
-				--data-dir=$(MDSHOW_CONFIG)/pandoc \
-				-f markdown+yaml_metadata_block \
-				-t revealjs \
-				--lua-filter fontawesome.lua \
-				--wrap=preserve \
-				--standalone \
-				--no-highlight \
-				--slide-level=2 \
-				-V revealjs-url=reveal.js \
-				-o $@ \
-				$${PANDOC_ARGS}
+    theme="$$($(MDSHOW_CONFIG)/reveal.js/node_modules/node-jq/bin/jq -r '.theme' < $(BUILD_DIR)/config.json)"; \
+    [ -e "$(MDSHOW_CONFIG)/theme/$${theme}/include/in-header.html" ] && PANDOC_ARGS="$${PANDOC_ARGS} --include-in-header=$(MDSHOW_CONFIG)/theme/$${theme}/include/in-header.html"; \
+    [ -e "$(MDSHOW_CONFIG)/theme/$${theme}/include/before-body.html" ] && PANDOC_ARGS="$${PANDOC_ARGS} --include-before-body=$(MDSHOW_CONFIG)/theme/$${theme}/include/before-body.html"; \
+    [ -e "$(MDSHOW_CONFIG)/theme/$${theme}/include/after-body.html" ] && PANDOC_ARGS="$${PANDOC_ARGS} --include-after-body=$(MDSHOW_CONFIG)/theme/$${theme}/include/after-body.html"; \
+    pandoc \
+    $(MDSHOW_CONFIG)/defaults.yaml \
+    $(SLIDES) \
+    --data-dir=$(MDSHOW_CONFIG)/pandoc \
+    -f markdown+yaml_metadata_block \
+    -t revealjs \
+    --lua-filter fontawesome.lua \
+    --wrap=preserve \
+    --standalone \
+    --no-highlight \
+    --slide-level=2 \
+    -V revealjs-url=reveal.js \
+    -o $@ \
+    $${PANDOC_ARGS}
 
 # {{{1 cleanup
 clean:

--- a/mdshow
+++ b/mdshow
@@ -1,13 +1,15 @@
 #!/usr/bin/make -f
 # TODO: newer versions of env support this: !/usr/bin/env -S make -f
-# NOTE Jürgen Haas: switched from yarn to npm, because yarn does not install node_modules/node-jp/bin
+# NOTE JH: switched from yarn to npm, because yarn does not install node_modules/node-jp/bin
 # Author: Jan Christoph Ebersbach <jceb@e-jc.de>
 # Copyright (c) 2020 Jan Christoph Ebersbach
 # License: Apache-2.0
 
 SHELL := /bin/bash
 
-MDSHOW_CONFIG = /opt/mdshow
+CONFIG_PATH = ${HOME}/.config
+MDSHOW_CONFIG = $(CONFIG_PATH)/mdshow
+
 SLIDES = slides.md
 BUILD_DIR = .build_$(basename $(SLIDES))
 PORT = 3000

--- a/mdshow.sh
+++ b/mdshow.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ -n $MDSHOW_THEME_PATH ]]; then
+  THEME=--volume=${MDSHOW_THEME_PATH}:/opt/mdshow/theme/$(basename ${MDSHOW_THEME_PATH})
+fi
+
+docker run --user=$(id -u) --rm -it --net=host ${THEME} --volume=$(pwd):/mdshow --workdir=/mdshow registry.lakedrops.com/docker/mdshow mdshow $@

--- a/mdshow.sh
+++ b/mdshow.sh
@@ -4,4 +4,4 @@ if [[ -n $MDSHOW_THEME_PATH ]]; then
   THEME=--volume=${MDSHOW_THEME_PATH}:/opt/mdshow/theme/$(basename ${MDSHOW_THEME_PATH})
 fi
 
-docker run --user=$(id -u) --rm -it --net=host ${THEME} --volume=$(pwd):/mdshow --workdir=/mdshow registry.lakedrops.com/docker/mdshow mdshow $@
+docker run --user=$(id -u) --rm -it --net=host ${THEME} --volume=$(pwd):/mdshow registry.lakedrops.com/docker/mdshow mdshow CONFIG_PATH=/opt $@

--- a/mdshow.sh
+++ b/mdshow.sh
@@ -4,4 +4,4 @@ if [[ -n $MDSHOW_THEME_PATH ]]; then
   THEME=--volume=${MDSHOW_THEME_PATH}:/opt/mdshow/theme/$(basename ${MDSHOW_THEME_PATH})
 fi
 
-docker run --user=$(id -u) --rm -it --net=host ${THEME} --volume=$(pwd):/mdshow registry.lakedrops.com/docker/mdshow mdshow CONFIG_PATH=/opt $@
+docker run --user=$(id -u) --rm -it --net=host ${THEME} --volume=$(pwd):/mdshow jceb/mdshow mdshow CONFIG_PATH=/opt $@


### PR DESCRIPTION
This PR provides:

**New files**

- docker-entrypoint.sh
- Dockerfile
- mdshow.sh: script to run on the host to start the Docker container and run mdshow commands.

**Changes in assets/pandoc/templates/default.revealjs**

Get theme CSS from `.mdshow/theme/...` instead of `$revealjs-url$/theme/...` because that way, custom themes that also provide additional assets and not only a css file are supported.

**Changes in mdshow**

- Switched from yarn to npm
- Changed config path from homedir to `/opt` because otherwise we run into permission issues as the host user is unknown inside the container
- Call `gulp css-themes` once in sync-custom-themes to get a potential custom theme being compiled initially and not only after updates
- Switch arguments in `$(MDSHOW_CONFIG)/reveal.js/dist/theme/%: $(MDSHOW_CONFIG)/theme/%/assets` and also use copy instead of link.
- Add new argument `--chrome-arg="--no-sandbox"` to PDF creation as the chrome process wouldn't launch otherwise.
